### PR TITLE
iOS14 pulldown fix

### DIFF
--- a/Source/DeckPresentationController.swift
+++ b/Source/DeckPresentationController.swift
@@ -291,13 +291,15 @@ final class DeckPresentationController: UIPresentationController, UIGestureRecog
         updateSnapshotViewAspectRatio()
         containerView.bringSubviewToFront(roundedViewForPresentedView)
         
-        if presentedViewController.view.isDescendant(of: containerView) {
-            UIView.animate(withDuration: 0.1) { [weak self] in
-                guard let `self` = self else {
-                    return
+        if #available(iOS 14, *) {} else {
+            if presentedViewController.view.isDescendant(of: containerView) {
+                UIView.animate(withDuration: 0.1) { [weak self] in
+                    guard let `self` = self else {
+                        return
+                    }
+                    
+                    self.presentedViewController.view.frame = self.frameOfPresentedViewInContainerView
                 }
-                
-                self.presentedViewController.view.frame = self.frameOfPresentedViewInContainerView
             }
         }
     }


### PR DESCRIPTION
Fixes #3037 (pocketcast-ios)

The DeckTransniton had a  "fix for janky transition". This is no longer required in iOS14. 
 In fact, this code now causes animation issues so don't run it for iOS14